### PR TITLE
implement distribute_size for expand

### DIFF
--- a/src/widgets/layout/expanded.rs
+++ b/src/widgets/layout/expanded.rs
@@ -4,6 +4,12 @@ use super::Constraints;
 use crate::widgets::ctx::LayoutCtx;
 use crate::widgets::{Direction, Expand, WidgetContainer};
 
+/// Distributes the total size over a list of weights
+///
+/// It uses the [Huntington-Hill method](https://en.wikipedia.org/wiki/Huntington%E2%80%93Hill_method)
+///
+/// Panics when called with more weights than the total number of available size.
+/// Allocates a minimum of one to each weight.
 fn distribute_size(weights: &[usize], mut total: usize) -> Vec<usize> {
     assert!(total > weights.len());
     let mut indexed = weights.iter().copied().enumerate().map(|(i, w)| (i, w, 1usize)).collect::<Vec<_>>();

--- a/src/widgets/layout/expanded.rs
+++ b/src/widgets/layout/expanded.rs
@@ -5,7 +5,26 @@ use crate::widgets::ctx::LayoutCtx;
 use crate::widgets::{Direction, Expand, WidgetContainer};
 
 fn distribute_size(weights: &[usize], mut total: usize) -> Vec<usize> {
-    todo!()
+    assert!(total > weights.len());
+    let mut indexed = weights.iter().copied().enumerate().map(|(i, w)| (i, w, 1usize)).collect::<Vec<_>>();
+    total -= weights.len();
+
+    fn pop(n: &mut usize) -> bool {
+        if let Some(nn) = n.checked_sub(1) {
+            *n = nn;
+            true
+        } else {
+            false
+        }
+    }
+
+    while pop(&mut total) {
+        indexed.sort_by_cached_key(|&(_, w, r)| (((w as f64) / ((r * (r + 1)) as f64).sqrt()) * -10000.) as isize);
+        indexed[0].2 += 1;
+    }
+
+    indexed.sort_by_key(|&(i, ..)| i);
+    indexed.into_iter().map(|(_, _, r)| r).collect()
 }
 
 pub fn layout(widgets: &mut [WidgetContainer], ctx: LayoutCtx, direction: Direction) -> Size {


### PR DESCRIPTION
I think we should somehow support too narrow constraints, and this can be optimized, by starting everyone off with the rounded down values.