### PR TITLE
chore(ci): update GH Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,21 +10,17 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
-
 jobs:
-
   test:
     runs-on: ubuntu-latest
     name: Test
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-
       - name: Configure cache
         uses: Swatinem/rust-cache@v2
-
       - name: Run tests
-        run: cargo test --verbose --all --all-features
+        run: cargo test --workspace --all-features --verbose
 
   lint:
     runs-on: ubuntu-latest
@@ -40,5 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - name: Configure cache
+        uses: Swatinem/rust-cache@v2
       - name: Clippy
-        run: cargo clippy --all-features --all
+        run: cargo clippy --workspace --all-features --all-targets

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -62,5 +62,5 @@ fn main() {
     // runtime.enable_alt_screen = false;
 
     // Step four: start the runtime
-    let _ = runtime.run().unwrap();
+    runtime.run().unwrap();
 }

--- a/examples/multiview.rs
+++ b/examples/multiview.rs
@@ -85,7 +85,7 @@ fn main() {
     // A prototype describes how to create a view when it's needed.
     // Use this when one or more views are created as a result of
     // some condition or loop
-    templates.add_prototype("item", item, || ItemView::new());
+    templates.add_prototype("item", item, ItemView::new);
 
     templates.compile().unwrap();
 


### PR DESCRIPTION
Replace the deprecated `--all` flag with `--workspace` and ensure that clippy is run over all targets (for example, including examples now).

Also, add the caching to the clippy lint step as well, because it can benefit from compilation artifacts.
