### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ anathema-value-derive = { path = "./anathema-value-derive" }
 workspace = true
 
 [workspace.dependencies]
-bitflags = "2.4.0"
+bitflags = "2.4.1"
 crossterm = "0.27.0"
-unicode-width = "0.1.10"
-thiserror = "1.0.40"
-flume = "0.10.14"
+unicode-width = "0.1.11"
+thiserror = "1.0.56"
+flume = "0.11.0"
 parking_lot = "0.12.1"
 kempt = "0.2.3"
 

--- a/anathema-value-derive/Cargo.toml
+++ b/anathema-value-derive/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-manyhow = "0.10.0"
-quote = "1.0.33"
-quote-use = "0.7.2"
-syn = "2.0.29"
+manyhow = "0.10.4"
+quote = "1.0.35"
+quote-use = "0.8.0"
+syn = "2.0.48"
 
 [lints]
 workspace = true


### PR DESCRIPTION
There have been new breaking releases for `flume` and `quote-use`, but it seems Anathema isn't affected so we can update without further adjustments.
