### PR TITLE
fixing wrong behavior when expanding without available space

### DIFF
--- a/anathema-default-widgets/src/layout/many.rs
+++ b/anathema-default-widgets/src/layout/many.rs
@@ -113,8 +113,8 @@ impl Many {
             }
         });
 
-        // Apply spacer and expand if the layout is constrained
-        if !self.unconstrained {
+        // Apply spacer and expand if the layout is constrained and we have remaining space
+        if !self.unconstrained && !self.used_size.no_space_left() {
             let constraints = self.used_size.to_constraints();
             let expanded_size = expand::layout_all_expansions(&mut children, constraints, self.axis, ctx);
             self.used_size.apply(expanded_size);


### PR DESCRIPTION
When expanding the layout without any available space we hit an assertion

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/9f3cf33c-f0de-4f86-a994-096d712490ba">

This pr intends to fix it