### PR TITLE
Added conversion of numbers for usizes

### DIFF
--- a/anathema-default-widgets/src/border.rs
+++ b/anathema-default-widgets/src/border.rs
@@ -419,12 +419,12 @@ impl Widget for Border {
         self.edges = self.border_style.edges();
 
         let mut layout = BorderLayout {
-            min_width: attributes.get(MIN_WIDTH),
-            min_height: attributes.get(MIN_HEIGHT),
-            max_width: attributes.get(MAX_WIDTH),
-            max_height: attributes.get(MAX_HEIGHT),
-            height: attributes.get_int(HEIGHT).map(|n| n as usize),
-            width: attributes.get_int(WIDTH).map(|n| n as usize),
+            min_width: attributes.get_usize(MIN_WIDTH),
+            min_height: attributes.get_usize(MIN_HEIGHT),
+            max_width: attributes.get_usize(MAX_WIDTH),
+            max_height: attributes.get_usize(MAX_HEIGHT),
+            height: attributes.get_usize(HEIGHT).map(|n| n as usize),
+            width: attributes.get_usize(WIDTH).map(|n| n as usize),
             border_size: self.border_size(self.sides),
         };
 

--- a/anathema-default-widgets/src/border.rs
+++ b/anathema-default-widgets/src/border.rs
@@ -423,8 +423,8 @@ impl Widget for Border {
             min_height: attributes.get_usize(MIN_HEIGHT),
             max_width: attributes.get_usize(MAX_WIDTH),
             max_height: attributes.get_usize(MAX_HEIGHT),
-            height: attributes.get_usize(HEIGHT).map(|n| n as usize),
-            width: attributes.get_usize(WIDTH).map(|n| n as usize),
+            height: attributes.get_usize(HEIGHT),
+            width: attributes.get_usize(WIDTH),
             border_size: self.border_size(self.sides),
         };
 

--- a/anathema-default-widgets/src/canvas.rs
+++ b/anathema-default-widgets/src/canvas.rs
@@ -162,12 +162,12 @@ impl Widget for Canvas {
     ) -> Size {
         let attribs = ctx.attribs.get(id);
 
-        if let Some(width @ 0..=i64::MAX) = attribs.get_int(WIDTH) {
-            constraints.set_max_width(width as usize);
+        if let Some(width) = attribs.get_usize(WIDTH) {
+            constraints.set_max_width(width);
         }
 
-        if let Some(height @ 0..=i64::MAX) = attribs.get_int(HEIGHT) {
-            constraints.set_max_height(height as usize);
+        if let Some(height) = attribs.get_usize(HEIGHT) {
+            constraints.set_max_height(height);
         }
 
         let size = constraints.max_size();

--- a/anathema-default-widgets/src/container.rs
+++ b/anathema-default-widgets/src/container.rs
@@ -21,28 +21,28 @@ impl Widget for Container {
 
         let attribs = ctx.attribs.get(id);
 
-        if let Some(width @ 0..=i64::MAX) = attribs.get(WIDTH) {
-            constraints.make_width_tight(width as usize);
+        if let Some(width) = attribs.get_usize(WIDTH) {
+            constraints.make_width_tight(width);
         }
 
-        if let Some(height @ 0..=i64::MAX) = attribs.get(HEIGHT) {
-            constraints.make_height_tight(height as usize);
+        if let Some(height) = attribs.get_usize(HEIGHT) {
+            constraints.make_height_tight(height);
         }
 
-        if let Some(width @ 0..=i64::MAX) = attribs.get(MIN_WIDTH) {
-            constraints.min_width = width as usize;
+        if let Some(width) = attribs.get_usize(MIN_WIDTH) {
+            constraints.min_width = width;
         }
 
-        if let Some(height @ 0..=i64::MAX) = attribs.get(MIN_HEIGHT) {
-            constraints.min_height = height as usize;
+        if let Some(height) = attribs.get_usize(MIN_HEIGHT) {
+            constraints.min_height = height;
         }
 
-        if let Some(width @ 0..=i64::MAX) = attribs.get(MAX_WIDTH) {
-            constraints.set_max_width(width as usize);
+        if let Some(width) = attribs.get_usize(MAX_WIDTH) {
+            constraints.set_max_width(width);
         }
 
-        if let Some(height @ 0..=i64::MAX) = attribs.get(MAX_HEIGHT) {
-            constraints.set_max_height(height as usize);
+        if let Some(height) = attribs.get_usize(MAX_HEIGHT) {
+            constraints.set_max_height(height);
         }
 
         children.for_each(|child, children| {

--- a/anathema-default-widgets/src/overflow.rs
+++ b/anathema-default-widgets/src/overflow.rs
@@ -124,11 +124,11 @@ impl Widget for Overflow {
             constraints.unbound_height();
         }
 
-        if let Some(width) = attributes.get(WIDTH) {
+        if let Some(width) = attributes.get_usize(WIDTH) {
             constraints.make_width_tight(width);
         }
 
-        if let Some(height) = attributes.get(HEIGHT) {
+        if let Some(height) = attributes.get_usize(HEIGHT) {
             constraints.make_height_tight(height);
         }
 

--- a/anathema-default-widgets/src/padding.rs
+++ b/anathema-default-widgets/src/padding.rs
@@ -40,10 +40,22 @@ impl Widget for Padding {
         let mut size = Size::ZERO;
         let padding = attributes.get(PADDING).unwrap_or(0);
 
-        self.0.top = attributes.get_usize(TOP).and_then(|v| v.try_into().ok()).unwrap_or(padding);
-        self.0.right = attributes.get_usize(RIGHT).and_then(|v| v.try_into().ok()).unwrap_or(padding);
-        self.0.bottom = attributes.get_usize(BOTTOM).and_then(|v| v.try_into().ok()).unwrap_or(padding);
-        self.0.left = attributes.get_usize(LEFT).and_then(|v| v.try_into().ok()).unwrap_or(padding);
+        self.0.top = attributes
+            .get_usize(TOP)
+            .and_then(|v| v.try_into().ok())
+            .unwrap_or(padding);
+        self.0.right = attributes
+            .get_usize(RIGHT)
+            .and_then(|v| v.try_into().ok())
+            .unwrap_or(padding);
+        self.0.bottom = attributes
+            .get_usize(BOTTOM)
+            .and_then(|v| v.try_into().ok())
+            .unwrap_or(padding);
+        self.0.left = attributes
+            .get_usize(LEFT)
+            .and_then(|v| v.try_into().ok())
+            .unwrap_or(padding);
 
         let padding_size = self.0.size();
 

--- a/anathema-default-widgets/src/padding.rs
+++ b/anathema-default-widgets/src/padding.rs
@@ -40,10 +40,10 @@ impl Widget for Padding {
         let mut size = Size::ZERO;
         let padding = attributes.get(PADDING).unwrap_or(0);
 
-        self.0.top = attributes.get(TOP).unwrap_or(padding);
-        self.0.right = attributes.get(RIGHT).unwrap_or(padding);
-        self.0.bottom = attributes.get(BOTTOM).unwrap_or(padding);
-        self.0.left = attributes.get(LEFT).unwrap_or(padding);
+        self.0.top = attributes.get_usize(TOP).and_then(|v| v.try_into().ok()).unwrap_or(padding);
+        self.0.right = attributes.get_usize(RIGHT).and_then(|v| v.try_into().ok()).unwrap_or(padding);
+        self.0.bottom = attributes.get_usize(BOTTOM).and_then(|v| v.try_into().ok()).unwrap_or(padding);
+        self.0.left = attributes.get_usize(LEFT).and_then(|v| v.try_into().ok()).unwrap_or(padding);
 
         let padding_size = self.0.size();
 

--- a/anathema-default-widgets/src/stacks/mod.rs
+++ b/anathema-default-widgets/src/stacks/mod.rs
@@ -31,19 +31,19 @@ impl Stack {
     ) -> Size {
         let attributes = ctx.attribs.get(id);
 
-        if let Some(width) = attributes.get(MIN_WIDTH) {
+        if let Some(width) = attributes.get_usize(MIN_WIDTH) {
             constraints.min_width = width;
         }
 
-        if let Some(height) = attributes.get(MIN_HEIGHT) {
+        if let Some(height) = attributes.get_usize(MIN_HEIGHT) {
             constraints.min_height = height;
         }
 
-        if let Some(width) = attributes.get(WIDTH) {
+        if let Some(width) = attributes.get_usize(WIDTH) {
             constraints.make_width_tight(width);
         }
 
-        if let Some(height) = attributes.get(HEIGHT) {
+        if let Some(height) = attributes.get_usize(HEIGHT) {
             constraints.make_height_tight(height);
         }
 

--- a/anathema-state/src/numbers.rs
+++ b/anathema-state/src/numbers.rs
@@ -5,7 +5,7 @@
 //!
 //! Note: If either the `lhs` or the `rhs` is a float then the entire
 //! number has to be treated as a float
-use std::{i16, i8, isize, f32, f64, ops::{Add, Div, Mul, Neg, Rem, Sub}};
+use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 
 use crate::{CommonVal, State};
 
@@ -66,7 +66,7 @@ impl Number {
 
     pub fn as_uint(self) -> usize {
         match self {
-            Self::Usize(n) => n as usize,
+            Self::Usize(n) => n,
             Self::Isize(n @ 0..isize::MAX) => n as usize,
             Self::U64(n) => n as usize,
             Self::I64(n @ 0..=i64::MAX) => n as usize,
@@ -78,7 +78,7 @@ impl Number {
             Self::I8(n @ 0..=i8::MAX) => n as usize,
             Self::F64(n @ 0.0..=f64::MAX) => n as usize,
             Self::F32(n @ 0.0..=f32::MAX) => n as usize,
-            _ => 0
+            _ => 0,
         }
     }
 }

--- a/anathema-state/src/numbers.rs
+++ b/anathema-state/src/numbers.rs
@@ -5,7 +5,7 @@
 //!
 //! Note: If either the `lhs` or the `rhs` is a float then the entire
 //! number has to be treated as a float
-use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
+use std::{i16, i8, isize, f32, f64, ops::{Add, Div, Mul, Neg, Rem, Sub}};
 
 use crate::{CommonVal, State};
 
@@ -62,6 +62,24 @@ impl Number {
 
     pub fn is_float(&self) -> bool {
         matches!(self, Self::F64(_) | Self::F32(_))
+    }
+
+    pub fn as_uint(self) -> usize {
+        match self {
+            Self::Usize(n) => n as usize,
+            Self::Isize(n @ 0..isize::MAX) => n as usize,
+            Self::U64(n) => n as usize,
+            Self::I64(n @ 0..=i64::MAX) => n as usize,
+            Self::U32(n) => n as usize,
+            Self::I32(n @ 0..=i32::MAX) => n as usize,
+            Self::U16(n) => n as usize,
+            Self::I16(n @ 0..=i16::MAX) => n as usize,
+            Self::U8(n) => n as usize,
+            Self::I8(n @ 0..=i8::MAX) => n as usize,
+            Self::F64(n @ 0.0..=f64::MAX) => n as usize,
+            Self::F32(n @ 0.0..=f32::MAX) => n as usize,
+            _ => 0
+        }
     }
 }
 

--- a/anathema-widgets/src/widget/attributes.rs
+++ b/anathema-widgets/src/widget/attributes.rs
@@ -142,7 +142,8 @@ impl<'bp> Attributes<'bp> {
 
     /// Get an unsigned integer regardless of how the value was stored.
     /// This will convert any state value of any numerical type
-    /// into a `u64`.
+    /// into a `usize`.
+    /// This will truncate any bits don't fit into a usize.
     pub fn get_usize(&self, key: &'bp str) -> Option<usize> {
         let key = ValueKey::Attribute(key);
 

--- a/anathema-widgets/src/widget/attributes.rs
+++ b/anathema-widgets/src/widget/attributes.rs
@@ -140,6 +140,18 @@ impl<'bp> Attributes<'bp> {
             .and_then(|e| e.load_number().map(|n| n.as_int()))
     }
 
+    /// Get an unsigned integer regardless of how the value was stored.
+    /// This will convert any state value of any numerical type
+    /// into a `u64`.
+    pub fn get_usize(&self, key: &'bp str) -> Option<usize> {
+        let key = ValueKey::Attribute(key);
+
+        let value = self.values.get(&key)?;
+        value
+            .load_common_val()
+            .and_then(|e| e.load_number().map(|n| n.as_uint()))
+    }
+
     pub(crate) fn get_mut_with_index(&mut self, index: SmallIndex) -> Option<&mut Value<'bp, EvalValue<'bp>>> {
         self.values.get_mut_with_index(index)
     }


### PR DESCRIPTION
This fixes a bug where if you don't specify a number in the exact type the widget expects, it will treat the number as if it wasn't set. For example, `container [width: width]` where the definition of width is `Value<usize>`, the container wouldn't be constrained to the width specified by the state, as it expected it to be `i64`. With this bugfix, that is no longer happening.