### PR TITLE
implement a more friendly derive macro for State

### DIFF
--- a/anathema-state-derive/Cargo.toml
+++ b/anathema-state-derive/Cargo.toml
@@ -7,10 +7,9 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-manyhow = "0.10.4"
+proc-macro2 = "1.0.95"
 quote = "1.0.35"
-quote-use = "0.8.0"
-syn = "2.0.48"
+syn = "2.0.48" # TODO determine which features we should actually use
 
 [lints]
 workspace = true

--- a/anathema-state-derive/src/attributes.rs
+++ b/anathema-state-derive/src/attributes.rs
@@ -1,0 +1,195 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use proc_macro2::Span;
+use syn::{Attribute, LitStr, spanned::Spanned as _};
+
+use crate::errors::{
+    reduce_errors, report_empty_value, report_exclusive_failure, report_unique_failure,
+    report_unknown_attribute,
+};
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum Constraint {
+    Unique,
+    Exclusive,
+    #[default]
+    Loose,
+}
+
+#[derive(Debug)]
+pub struct ParsedAttr {
+    pub key: Span,
+    pub value: Option<Spanned<String>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Spanned<T> {
+    pub span: Span,
+    pub value: T,
+}
+
+#[derive(Clone, Debug)]
+struct Attr {
+    key: Spanned<String>,
+    value: Option<Spanned<String>>,
+}
+
+fn parse_attr(errors: &mut Vec<syn::Error>, attr: &Attribute) -> Vec<Attr> {
+    let attr_list = match attr.meta.require_list() {
+        Ok(attr_list) => attr_list,
+        Err(err) => {
+            if let Ok(path) = attr
+                .meta
+                .require_path_only()
+                .and_then(|p| p.require_ident())
+            {
+                return vec![Attr {
+                    key: Spanned {
+                        span: path.span(),
+                        value: path.to_string().trim().to_string(),
+                    },
+                    value: None,
+                }];
+            }
+
+            errors.push(err);
+            return vec![];
+        }
+    };
+
+    let mut out = vec![];
+    let Err(err) = attr_list.parse_nested_meta(|meta| {
+        let path = &meta.path;
+
+        let ident = path.require_ident()?;
+        let ident_name = ident.to_string();
+
+        enum Kind {
+            Value { data: String, span: Span },
+            Key { span: Span },
+        }
+
+        let kind = meta
+            .value()
+            .and_then(|c| {
+                let value = c.parse::<LitStr>()?;
+                Ok(Kind::Value {
+                    data: value.value().trim().to_string(),
+                    span: value.span(),
+                })
+            })
+            .unwrap_or_else(|_| Kind::Key { span: ident.span() });
+
+        let (data, value_span) = match kind {
+            Kind::Value { data, span } => {
+                if data.trim().is_empty() {
+                    errors.push(report_empty_value(&ident_name, span));
+                    return Ok(());
+                }
+                (Some(data), span)
+            }
+            Kind::Key { span } => (None, span),
+        };
+
+        out.push(Attr {
+            key: Spanned {
+                span: meta.path.span(),
+                value: ident_name,
+            },
+            value: data.map(|value| Spanned {
+                span: value_span,
+                value,
+            }),
+        });
+
+        Ok(())
+    }) else {
+        return out;
+    };
+
+    errors.push(err);
+    vec![]
+}
+
+pub fn parse_attrs(
+    namespace: &str,
+    attrs: &[Attribute],
+    allowed: &[(&'static str, Constraint)],
+    deprecated: &[(&'static str, Constraint)],
+) -> Result<HashMap<String, ParsedAttr>, syn::Error> {
+    let mapping = allowed.iter().copied().collect::<BTreeMap<_, _>>();
+
+    let mut errors = Vec::new();
+    let mut parsed = HashMap::new();
+
+    let mut is_unique = None;
+    let mut seen = <HashSet<String>>::new();
+
+    for attr in attrs {
+        if !deprecated
+            .iter()
+            .any(|(name, _)| attr.path().is_ident(name))
+            && !attr.path().is_ident(namespace)
+        {
+            continue;
+        }
+
+        for Attr { key, value } in parse_attr(&mut errors, attr) {
+            match mapping.get(&*key.value).or_else(|| {
+                deprecated
+                    .iter()
+                    .find_map(|(name, constraint)| (&key.value == name).then_some(constraint))
+            }) {
+                Some(constraint) => match constraint {
+                    Constraint::Unique if is_unique.is_some() => {
+                        errors.push(report_unique_failure(&key.value, key.span));
+                        continue;
+                    }
+                    Constraint::Unique => {
+                        if !seen.is_empty() {
+                            errors.push(report_unique_failure(&key.value, key.span));
+                            continue;
+                        }
+
+                        is_unique = Some(Attr {
+                            key: key.clone(),
+                            value: value.clone(),
+                        });
+                    }
+
+                    Constraint::Exclusive if is_unique.is_none() => {
+                        if !seen.insert(key.value.clone()) {
+                            errors.push(report_exclusive_failure(&key.value, key.span));
+                            continue;
+                        }
+                    }
+
+                    _ if is_unique.is_some() => {
+                        let Attr { key, .. } = is_unique.as_ref().unwrap();
+                        errors.push(report_unique_failure(&key.value, key.span));
+                        continue;
+                    }
+                    _ => {}
+                },
+
+                None => {
+                    errors.push(report_unknown_attribute(
+                        mapping.keys(),
+                        &key.value,
+                        key.span,
+                    ));
+                    continue;
+                }
+            }
+
+            let value = ParsedAttr {
+                key: key.span,
+                value,
+            };
+            parsed.insert(key.value, value);
+        }
+    }
+
+    reduce_errors(parsed, errors)
+}

--- a/anathema-state-derive/src/errors.rs
+++ b/anathema-state-derive/src/errors.rs
@@ -1,0 +1,52 @@
+use proc_macro2::Span;
+
+pub fn report_missing_data(span: Span) -> syn::Error {
+    syn::Error::new(span, "a string value is required")
+}
+
+pub fn report_empty_value(attr: &str, span: Span) -> syn::Error {
+    syn::Error::new(span, format!("value cannot be empty for '{attr}'"))
+}
+
+pub fn report_exclusive_failure(attr: &str, span: Span) -> syn::Error {
+    syn::Error::new(span, format!("'{attr}' cannot be used more than once"))
+}
+
+pub fn report_unique_failure(attr: &str, span: Span) -> syn::Error {
+    syn::Error::new(
+        span,
+        format!(
+            "'{attr}' cannot be used with other {} attributes",
+            crate::DERIVE_NAMESPACE
+        ),
+    )
+}
+
+pub fn report_unknown_attribute<T: AsRef<str>>(
+    available: impl IntoIterator<Item = T>,
+    found: &str,
+    span: Span,
+) -> syn::Error {
+    let known = available.into_iter().fold(String::new(), |mut a, c| {
+        if !a.is_empty() {
+            a.push_str(", ");
+        }
+        a.push_str(c.as_ref());
+        a
+    });
+    let message = format!("unknown attribute: {found}, supported: {known}",);
+    syn::Error::new(span, message)
+}
+
+pub fn reduce_errors<T>(
+    okay: T,
+    errors: impl IntoIterator<Item = syn::Error>,
+) -> Result<T, syn::Error> {
+    let Some(errors) = errors.into_iter().reduce(|mut left, right| {
+        left.combine(right);
+        left
+    }) else {
+        return Ok(okay);
+    };
+    Err(errors)
+}

--- a/anathema-state-derive/src/lib.rs
+++ b/anathema-state-derive/src/lib.rs
@@ -1,62 +1,31 @@
-use manyhow::{ensure, manyhow, Result};
-use quote_use::quote_use as quote;
-use syn::{self, Data, DeriveInput, Fields};
+use syn::{DeriveInput, parse_macro_input, spanned::Spanned as _};
 
-static STATE_IGNORE: &str = "state_ignore";
+static DERIVE_NAMESPACE: &str = "anathema";
 
-#[manyhow]
-#[proc_macro_derive(State, attributes(state_ignore))]
-pub fn state_derive(input: DeriveInput) -> Result {
-    let name = &input.ident;
+#[proc_macro_derive(State, attributes(anathema, state_ignore))]
+pub fn anathema(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match &input.data {
+        syn::Data::Struct(data) => structs::generate(&input, data),
 
-    ensure!(let Data::Struct(strct) = &input.data, input, "only structs are supported");
+        syn::Data::Enum(data) => syn::Error::new(
+            data.enum_token.span(), //
+            "anathema's State cannot be derived on enums currently",
+        )
+        .to_compile_error()
+        .into(),
 
-    ensure!(
-        let Fields::Named(struct_fields) = &strct.fields,
-        strct.fields,
-        "only named fields"
-    );
-
-    let (field_idents, field_names): (Vec<_>, Vec<_>) = struct_fields
-        .named
-        .iter()
-        .filter(|f| {
-            // Ignore all `STATE_IGNORE` attributes
-            !f.attrs.iter().any(|attr| attr.path().is_ident(STATE_IGNORE))
-        })
-        .filter_map(|f| f.ident.as_ref())
-        .map(|f| (f, f.to_string()))
-        .unzip();
-
-    Ok(quote! {
-        # use ::anathema::state::{self, AnyMap, Type, Value, ValueRef, PendingValue, Path, state, Subscriber, CommonVal};
-        # use ::std::any::Any;
-
-        impl state::TypeId for #name {
-            const TYPE: Type = Type::Composite;
+        syn::Data::Union(data) => {
+            syn::Error::new(
+                data.union_token.span(), //
+                "anathema's State cannot be derived on unions currently",
+            )
+            .to_compile_error()
+            .into()
         }
-
-        impl state::State for #name {
-            fn type_info(&self) -> Type {
-                Type::Composite
-            }
-
-            fn as_any_map(&self) -> Option<&dyn AnyMap> {
-                Some(self)
-            }
-        }
-
-        impl state::AnyMap for #name {
-            fn lookup(&self, key: &str) -> Option<PendingValue> {
-                match key.as_ref() {
-                    #(
-                        #field_names => {
-                            Some(self.#field_idents.reference())
-                        }
-                    )*
-                    _ => None,
-                }
-            }
-        }
-    })
+    }
 }
+
+mod attributes;
+mod errors;
+mod structs;

--- a/anathema-state-derive/src/structs.rs
+++ b/anathema-state-derive/src/structs.rs
@@ -1,0 +1,300 @@
+use crate::{
+    attributes::{Constraint, Spanned, parse_attrs},
+    errors::{reduce_errors, report_missing_data},
+};
+
+use proc_macro2::Span;
+use std::collections::HashMap;
+use syn::{DataStruct, DeriveInput, Field, Fields, Ident, spanned::Spanned as _};
+
+static FIELD_RENAME: &str = "rename";
+static FIELD_IGNORE: &str = "ignore";
+static STATE_IGNORE: &str = "state_ignore";
+
+const AVAILABLE_ATTRIBUTES: &[(&str, Constraint)] = &[
+    (FIELD_RENAME, Constraint::Exclusive),
+    (FIELD_IGNORE, Constraint::Unique),
+];
+
+const DEPRECATED_ATTRIBUTES: &[(&str, Constraint)] = &[
+    (STATE_IGNORE, Constraint::Unique), //
+];
+
+pub fn generate(input: &DeriveInput, data: &DataStruct) -> proc_macro::TokenStream {
+    let kind = match collect_fields(
+        &data.fields,
+        AVAILABLE_ATTRIBUTES, //
+        DEPRECATED_ATTRIBUTES,
+    ) {
+        Ok(kind) => kind,
+        Err(err) => return err.into_compile_error().into(),
+    };
+
+    match kind {
+        GenerateKind::Composite { fields } => generate_composite(&input.ident, fields),
+        GenerateKind::List { len } => generate_list(&input.ident, len),
+        GenerateKind::Unit => generate_unit(&input.ident),
+    }
+}
+
+fn generate_unit(name: &Ident) -> proc_macro::TokenStream {
+    quote::quote! {
+        impl ::anathema::state::State for #name {
+            fn type_info(&self) -> ::anathema::state::Type {
+                ::anathema::state::Type::Unit
+            }
+        }
+
+        impl ::anathema::state::TypeId for #name {
+            const TYPE: ::anathema::state::Type = ::anathema::state::Type::Unit;
+        }
+    }
+    .into()
+}
+
+fn generate_list(name: &Ident, len: usize) -> proc_macro::TokenStream {
+    let iter = (0..len).map(|n| {
+        let n = syn::Index::from(n);
+        quote::quote! {
+            #n => Some(self.#n.reference())
+        }
+    });
+
+    quote::quote! {
+        impl ::anathema::state::State for #name {
+            fn type_info(&self) -> ::anathema::state::Type {
+                ::anathema::state::Type::List
+            }
+        }
+
+        impl ::anathema::state::TypeId for #name {
+            const TYPE: ::anathema::state::Type = ::anathema::state::Type::List;
+        }
+
+        impl ::anathema::state::AnyList for #name {
+            fn lookup(&self, index: usize) -> Option<::anathema::state::PendingValue> {
+                match index {
+                    #( #iter, )*
+                    _ => None
+                }
+            }
+
+            fn len(&self) -> usize {
+                #len
+            }
+        }
+    }
+    .into()
+}
+
+fn generate_composite(name: &Ident, fields: Vec<data::Field>) -> proc_macro::TokenStream {
+    let field_names = fields
+        .iter()
+        .map(|data::Field { display_name, .. }| quote::quote! { #display_name });
+
+    let field_idents = fields
+        .iter()
+        .map(
+            |data::Field {
+                 name: Spanned { span, value },
+                 ..
+             }| syn::Ident::new(value, *span),
+        )
+        .map(|ident| {
+            let span = ident.span();
+            quote::quote_spanned! {span=> Some(self.#ident.reference())}
+        });
+
+    quote::quote! {
+        impl ::anathema::state::State for #name {
+            fn type_info(&self) -> ::anathema::state::Type {
+                ::anathema::state::Type::Composite
+            }
+
+            fn as_any_map(&self) -> Option<&dyn ::anathema::state::AnyMap> {
+                Some(self)
+            }
+        }
+
+        impl ::anathema::state::TypeId for #name {
+            const TYPE: ::anathema::state::Type = ::anathema::state::Type::Composite;
+        }
+
+        impl ::anathema::state::AnyMap for #name {
+            fn lookup(&self, key: &str) -> Option<::anathema::state::PendingValue> {
+                match key {
+                    #(
+                        #field_names => {
+                            #field_idents
+                        },
+                    )*
+                    _ => None,
+                }
+            }
+        }
+    }
+    .into()
+}
+
+mod data {
+    use crate::attributes::Spanned;
+
+    pub struct Field {
+        pub name: Spanned<String>,
+        pub display_name: String,
+    }
+}
+
+enum GenerateKind {
+    Composite { fields: Vec<data::Field> },
+    List { len: usize },
+    Unit,
+}
+
+fn has_attributes(fields: &Fields, deprecated_attributes: &[(&str, Constraint)]) -> bool {
+    let count = |field: &Field| {
+        field
+            .attrs
+            .iter()
+            .filter(|c| {
+                deprecated_attributes
+                    .iter()
+                    .any(|(name, _)| c.meta.path().is_ident(name))
+                    || c.meta.path().is_ident(crate::DERIVE_NAMESPACE)
+            })
+            .count()
+    };
+    fields.iter().map(count).sum::<usize>() > 0
+}
+
+#[derive(Debug)]
+struct SpannedField {
+    field_name: Spanned<String>,
+    rename: Option<Spanned<String>>,
+}
+
+fn check_duplicate_renames(values: &[SpannedField]) -> Option<Vec<syn::Error>> {
+    let mut seen = <HashMap<&str, Vec<Span>>>::new();
+
+    for value in values {
+        let (name, span) = value
+            .rename
+            .as_ref()
+            .map(|rename| (&rename.value, rename.span))
+            .unwrap_or((&value.field_name.value, value.field_name.span));
+        seen.entry(name).or_default().push(span);
+    }
+
+    let duplicate_spans = seen
+        .into_iter()
+        .filter(|(_, list)| list.len() > 1)
+        .collect::<Vec<_>>();
+
+    if duplicate_spans.is_empty() {
+        return None;
+    }
+
+    let mut errors = vec![];
+    for (name, mut dupe) in duplicate_spans {
+        let message = format!("duplicate name '{name}' used here");
+        let mut error = syn::Error::new(dupe.remove(0), message);
+        for span in dupe {
+            let message = format!("'{name}' is also used here");
+            error.combine(syn::Error::new(span, message))
+        }
+        errors.push(error);
+    }
+
+    Some(errors)
+}
+
+fn collect_fields(
+    fields: &Fields,
+    available_attributes: &[(&'static str, Constraint)],
+    deprecated_attributes: &[(&'static str, Constraint)],
+) -> Result<GenerateKind, syn::Error> {
+    if matches!(fields, Fields::Unnamed(..)) {
+        if has_attributes(fields, deprecated_attributes) {
+            return Err(syn::Error::new(
+                fields.span(),
+                "anathema attributes on tuple structs aren't currently supported",
+            ));
+        }
+        return Ok(GenerateKind::List { len: fields.len() });
+    }
+
+    if fields.is_empty() {
+        return Ok(GenerateKind::Unit);
+    }
+
+    let mut out = vec![];
+    let mut errors = vec![];
+    let mut seen = vec![];
+
+    for field in fields {
+        let mut kvs = match parse_attrs(
+            crate::DERIVE_NAMESPACE, //
+            &field.attrs,
+            available_attributes,
+            deprecated_attributes,
+        ) {
+            Ok(kvs) => kvs,
+            Err(err) => {
+                errors.push(err);
+                continue;
+            }
+        };
+
+        let name = match &field.ident {
+            Some(name) => name,
+            None => {
+                errors.push(syn::Error::new(
+                    field.span(),
+                    "anathema's attributes cannot be applied to unnamed fields",
+                ));
+                continue;
+            }
+        };
+
+        // the duplicate check doesn't need to know about ignored fields
+        if kvs.remove(FIELD_IGNORE).is_some() || kvs.remove(STATE_IGNORE).is_some() {
+            continue;
+        }
+
+        let field_name = Spanned {
+            value: name.to_string(),
+            span: field.span(),
+        };
+
+        let rename = match kvs.remove(FIELD_RENAME) {
+            Some(parsed) => {
+                #[allow(clippy::let_and_return)] // clippy is totally wrong about this
+                let value @ Some(..) = parsed.value else {
+                    errors.push(report_missing_data(parsed.key));
+                    continue;
+                };
+                value
+            }
+            None => None,
+        };
+
+        out.push(data::Field {
+            name: Spanned {
+                span: field.span(),
+                value: field_name.value.clone(),
+            },
+            display_name: rename
+                .as_ref()
+                .map(|c| c.value.clone())
+                .unwrap_or_else(|| field_name.value.clone())
+                .trim()
+                .to_string(),
+        });
+        seen.push(SpannedField { field_name, rename });
+    }
+
+    errors.extend(check_duplicate_renames(&seen).into_iter().flatten());
+    // errors.reverse();
+
+    reduce_errors(GenerateKind::Composite { fields: out }, errors)
+}


### PR DESCRIPTION
State can be derived on Unit structs (as Type::Unit) State can be derived on Tuple structs (as Type::List)

`#[state_ignore]` still exists but:
`#[anathema(ignore)]` is a more 'unified' form of it

and I added:
`#[anathema(rename = "name")]` which can be used
to rename a field from the `aml` side of things

Note: the attributes cannot be currently used in
unit/tuple structs.

Example:

```rust
use anathema::{State, state::Value}; // TODO prelude names for this

struct AppState {
    #[anathema(ignore)]
    inner: bool

    #[anathema(rename = "text")]
    data: Value<String>
}
```

This'll allow the state's data to be referenced as `.text` from the template, but stay as 'data' on
the rust side.