### PR TITLE
Fixed widget filters not correctly filtering out elements

### DIFF
--- a/anathema-widgets/src/query/mod.rs
+++ b/anathema-widgets/src/query/mod.rs
@@ -163,7 +163,7 @@ where
     type Kind = A::Kind;
 
     fn filter(&self, arg: &Self::Kind, attributes: &mut AttributeStorage<'bp>) -> bool {
-        self.a.filter(arg, attributes) | self.b.filter(arg, attributes)
+        self.a.filter(arg, attributes) && self.b.filter(arg, attributes)
     }
 }
 


### PR DESCRIPTION
Widget filters previously checked if any of the conditions were true, not if all were, which is what was the expected behavior. 