### PR TITLE
Prevent the keyword 'state' from getting used in a declaration

### DIFF
--- a/anathema-templates/src/statements/eval.rs
+++ b/anathema-templates/src/statements/eval.rs
@@ -260,7 +260,7 @@ mod test {
         let response = doc.compile();
         assert_eq!(
             response.err().unwrap().to_string(),
-            "invalid statement: state is a reserved keyword"
+            "invalid statement: state is a reserved identifier"
         );
     }
 


### PR DESCRIPTION
I could not determine if there was a better way to find the keyword 'state', for example whether keywords are an enum somewhere?
This prevents the user from using the keyword `state` as a variable declaration.

fixes: #108 